### PR TITLE
[fix] spring security authorizerequests 메소드 deprecated되어 수정

### DIFF
--- a/kttr-api/src/main/java/com/crs/kttr/config/SecurityConfig.java
+++ b/kttr-api/src/main/java/com/crs/kttr/config/SecurityConfig.java
@@ -7,18 +7,13 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
-  /**
-   *
-   * @param http
-   * @return
-   * @throws Exception
-   */
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    return http.authorizeRequests((authz) -> authz
-        .requestMatchers("/health/**").permitAll()
-        .anyRequest()
-        .authenticated()
-    ).build();
+    return http.authorizeHttpRequests()
+      .requestMatchers("/health/**").permitAll()
+      .anyRequest()
+      .authenticated()
+      .and()
+      .build();
   }
 }


### PR DESCRIPTION
spring security에 사용한 메소드가 deprecated 되어 수정함.

authorizeRequests -> authorizeHttpRequests